### PR TITLE
Add why section for internships route

### DIFF
--- a/app/dashboard/internships/page.jsx
+++ b/app/dashboard/internships/page.jsx
@@ -21,6 +21,8 @@ import {
   Monitor,
   ExternalLink,
   Terminal,
+  BriefcaseIcon,
+  ArrowRight,
 } from 'lucide-react';
 
 export default function Internships() {
@@ -154,6 +156,31 @@ export default function Internships() {
             Whether you are looking for internships or preparing for interviews,
             these resources will help you succeed.
           </p>
+        </CardContent>
+      </Card>
+
+      <Card className='mb-8 shadow-lg hover:shadow-xl transition-shadow duration-300 bg-gradient-to-r from-yellow-50 to-orange-50 dark:from-gray-800 dark:to-gray-900'>
+        <CardHeader>
+          <CardTitle className='text-2xl font-bold flex items-center text-yellow-600 dark:text-yellow-400'>
+            <BriefcaseIcon className='h-6 w-6 mr-2' />
+            Why Pursue Internships?
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className='list-none pl-5 space-y-2'>
+            {[
+              'Gain real-world experience in a professional setting',
+              'Apply theoretical knowledge to practical projects',
+              'Expand your professional network and mentorship opportunities',
+              'Enhance your resume with hands-on experience',
+              'Discover career paths and industry insights early on',
+            ].map((item, index) => (
+              <li key={index} className='flex items-start'>
+                <ArrowRight className='h-5 w-5 mr-2 text-yellow-500 flex-shrink-0 mt-1' />
+                <span className='text-gray-700 dark:text-gray-200'>{item}</span>
+              </li>
+            ))}
+          </ul>
         </CardContent>
       </Card>
 

--- a/app/dashboard/tools/page.jsx
+++ b/app/dashboard/tools/page.jsx
@@ -273,8 +273,11 @@ export default function ToolsAndResources() {
             Tools & Resources
           </CardTitle>
           <CardDescription className='text-lg'>
-            Explore essential tools, platforms, and skills for modern software
-            development, including free cloud resources.
+            Discover powerful free tools, platforms, and resources we have
+            handpicked to help you build amazing projects without spending a
+            dime. Whether you are working on hobby projects, sharpening your
+            skills, or just starting out, these essentials will give you a head
+            start in modern software development.
           </CardDescription>
         </CardHeader>
       </Card>


### PR DESCRIPTION
This PR adds a "Why" section to the `/dashboard/internships` route. It also updates the copy in our `/dashboard/tools` route, check commits to see what changed. 

#### The added "Why" section in the internships route

![Screenshot 2025-01-14 at 11 38 40 AM](https://github.com/user-attachments/assets/18354e63-7c9e-4cec-8176-b8e654e9f97f)

