### PR TITLE
Add tos/pp agreements in auth page

### DIFF
--- a/app/login/page.jsx
+++ b/app/login/page.jsx
@@ -25,6 +25,7 @@ import {
   googleAuth,
   signInWithEmail,
 } from '../../lib/actions/auth';
+import Link from 'next/link';
 
 export default function AuthForm() {
   const [activeTab, setActiveTab] = useState('signin');
@@ -235,6 +236,23 @@ export default function AuthForm() {
                 ? 'Sign In with Google'
                 : 'Sign Up with Google'}
             </Button>
+            <p className='text-center text-sm mt-5'>
+              By signing up, you agree to our{' '}
+              <Link
+                href='/terms-of-service'
+                className='text-underline text-primary'
+              >
+                Terms
+              </Link>{' '}
+              &{' '}
+              <Link
+                href='/privacy-policy'
+                className='text-underline text-primary'
+              >
+                Privacy
+              </Link>
+              .
+            </p>
           </form>
         </CardFooter>
       </Card>

--- a/app/privacy-policy/page.jsx
+++ b/app/privacy-policy/page.jsx
@@ -57,9 +57,8 @@ const PrivacyPolicyPage = () => {
             <p>
               We collect information that you provide directly to us, such as
               when you create an account, subscribe to our waitlist, or
-              communicate with us. This may include your name, email address
-              (specifically .edu email addresses), and any other information you
-              choose to provide.
+              communicate with us. This may include your name, any type of email
+              address, and any other information you choose to provide.
             </p>
           </section>
 


### PR DESCRIPTION
This PR adds an agreement between the user and our platform in our `/login` route. Adding the agreement in the `/login` route is convenient us. 

### Before changes 
![Screenshot 2025-01-22 at 3 04 22 PM](https://github.com/user-attachments/assets/10ff7334-7d7b-4841-a833-e9a486d7fa62)

### After changes 
![Screenshot 2025-01-22 at 3 15 24 PM](https://github.com/user-attachments/assets/996b864b-2767-4096-8af3-f796de731ca5)
