### PR TITLE
Improvements

### DIFF
--- a/app/not-found.jsx
+++ b/app/not-found.jsx
@@ -20,7 +20,7 @@ export default function NotFound() {
         moved.
       </p>
       <div className='mt-8 flex justify-center gap-2'>
-        <Button onClick={() => router.push('/dashboard')} size='lg'>
+        <Button onClick={() => router.push('/')} size='lg'>
           Back to Home
         </Button>
       </div>

--- a/app/privacy-policy/page.jsx
+++ b/app/privacy-policy/page.jsx
@@ -154,7 +154,7 @@ const PrivacyPolicyPage = () => {
             </h2>
             <p>
               If you have any questions about this Privacy Policy, please
-              contact us at [Your Contact Email].
+              contact us at team@phazeone.tech.
             </p>
           </section>
         </div>

--- a/app/terms-of-service/page.jsx
+++ b/app/terms-of-service/page.jsx
@@ -147,7 +147,7 @@ const TermsOfServicePage = () => {
             </h2>
             <p>
               If you have any questions about these Terms, please contact us at
-              [Your Contact Email].
+              team@phazeone.tech.
             </p>
           </section>
         </div>

--- a/components/landingpage/blogcontent.js
+++ b/components/landingpage/blogcontent.js
@@ -3,37 +3,42 @@ import React from 'react';
 import { motion } from 'framer-motion';
 
 const blogContent = {
-  title: "PhazeOne: Guiding Freshmen and Sophomores Through the Foundations of Tech Careers",
+  title:
+    'PhazeOne: Guiding Freshmen and Sophomores Through the Foundations of Tech Careers',
   sections: [
     {
-      title: "Introduction",
-      content: "Embarking on a Computer Science (CS) journey in your freshman or sophomore year is both exciting and filled with questions. " +
-          "At PhazeOne, we recognize the unique challenges early-stage students face and are dedicated to providing tailored resources to set you on the path to success."
+      title: 'Introduction',
+      content:
+        'Embarking on a Sofware Engineering (SWE) journey in your freshman or sophomore year is both exciting and filled with questions. ' +
+        'At PhazeOne, we recognize the unique challenges early-stage students face and are dedicated to providing tailored resources to set you on the path to success.',
     },
     {
-      title: "Understanding the Early Challenges",
+      title: 'Understanding the Early Challenges',
       // Updated content for the "Understanding the Early Challenges" section
-      content: "As a first or second-year CS student, you're likely facing several common challenges that make securing that first internship particularly difficult:" +
-          "\n\n**Navigating the Starting Line:** You may feel overwhelmed about where to begin. Choosing the right programming language to learn first, " +
-          "figuring out how to build meaningful projects that showcase your skills, and finding reliable resources for internships and resume preparation are often unclear." +
-          "\n\n**Limited Access to Opportunities:** Without established professional networks, you probably find it challenging to discover industry events, coding competitions, " +
-          "or mentorship programs. These connections are crucial for enhancing your profile and opening doors to opportunities that aren't visible through standard job boards.\n\n**Hidden Career Resources:** " +
-          "Many valuable opportunities remain hidden from view. Company-sponsored programs, specialized networking events, and early-career initiatives often aren't widely advertised, leaving you unaware of these crucial stepping stones " +
-          "that could accelerate your path to success."
+      content:
+        "As a first or second-year SWE student, you're likely facing several common challenges that make securing that first internship particularly difficult:" +
+        '\n\n**Navigating the Starting Line:** You may feel overwhelmed about where to begin. Choosing the right programming language to learn first, ' +
+        'figuring out how to build meaningful projects that showcase your skills, and finding reliable resources for internships and resume preparation are often unclear.' +
+        '\n\n**Limited Access to Opportunities:** Without established professional networks, you probably find it challenging to discover industry events, coding competitions, ' +
+        "or mentorship programs. These connections are crucial for enhancing your profile and opening doors to opportunities that aren't visible through standard job boards.\n\n**Hidden Career Resources:** " +
+        "Many valuable opportunities remain hidden from view. Company-sponsored programs, specialized networking events, and early-career initiatives often aren't widely advertised, leaving you unaware of these crucial stepping stones " +
+        'that could accelerate your path to success.',
     },
     {
-      title: "PhazeOne: Your Foundational Toolkit",
-      content: "To support you, PhazeOne offers:\n\n**Curated Learning Paths:** Personalized recommendations on programming languages and project ideas aligned with current industry trends, " +
-          "helping you build a strong foundation.\n\n**Access to Exclusive Opportunities:** Information on internships, workshops, and events specifically designed for underclassmen to gain practical " +
-          "experience.\n\n**Comprehensive Career Resources:** Guidance on crafting compelling resumes, preparing for technical interviews, and building a professional online presence from the outset."
+      title: 'PhazeOne: Your Foundational Toolkit',
+      content:
+        'To support you, PhazeOne offers:\n\n**Curated Learning Paths:** Personalized recommendations on programming languages and project ideas aligned with current industry trends, ' +
+        'helping you build a strong foundation.\n\n**Access to Exclusive Opportunities:** Information on internships, workshops, and events specifically designed for underclassmen to gain practical ' +
+        'experience.\n\n**Comprehensive Career Resources:** Guidance on crafting compelling resumes, preparing for technical interviews, and building a professional online presence from the outset.',
     },
     {
-      title: "Empowering Your Early Success",
-      content: "By leveraging PhazeOne's resources, you can:\n\n**Establish a Strong Foundation:** Gain clarity on where to begin and how to progress effectively in your CS career.\n\n**Expand Your Network:" +
-          "** Connect with peers, mentors, and industry professionals who can provide valuable insights and opportunities.\n\n**Stay Informed:** Keep abreast of emerging trends and opportunities that align with your career aspirations." +
-          "\n\nAt PhazeOne, we believe that with the right support and resources, every CS student can achieve their professional goals. Let us be your partner in this journey toward securing that essential first internship and beyond."
-    }
-  ]
+      title: 'Empowering Your Early Success',
+      content:
+        "By leveraging PhazeOne's resources, you can:\n\n**Establish a Strong Foundation:** Gain clarity on where to begin and how to progress effectively in your SWE career.\n\n**Expand Your Network:" +
+        '** Connect with peers, mentors, and industry professionals who can provide valuable insights and opportunities.\n\n**Stay Informed:** Keep abreast of emerging trends and opportunities that align with your career aspirations.' +
+        '\n\nAt PhazeOne, we believe that with the right support and resources, every SWE student can achieve their professional goals. Let us be your partner in this journey toward securing that essential first internship and beyond.',
+    },
+  ],
 };
 
 // Helper function to format text with bold elements
@@ -46,7 +51,11 @@ const formatTextWithBold = (text) => {
     if (part.startsWith('**') && part.endsWith('**')) {
       // Extract the text between ** and **
       const boldText = part.substring(2, part.length - 2);
-      return <span key={index} className="font-bold">{boldText}</span>;
+      return (
+        <span key={index} className='font-bold'>
+          {boldText}
+        </span>
+      );
     }
     return part;
   });
@@ -54,68 +63,68 @@ const formatTextWithBold = (text) => {
 
 const BlogContent = ({ onJoinWaitlist }) => {
   return (
-      <motion.article
-          className={`prose prose-lg prose-invert mx-auto`}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.5 }}
+    <motion.article
+      className={`prose prose-lg prose-invert mx-auto`}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.5 }}
+    >
+      <motion.h1
+        className='text-3xl md:text-5xl font-extrabold mb-8 bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent leading-tight text-center'
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.5 }}
       >
-        <motion.h1
-            className='text-3xl md:text-5xl font-extrabold mb-8 bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent leading-tight text-center'
-            initial={{ opacity: 0, y: -20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2, duration: 0.5 }}
-        >
-          {blogContent.title}
-        </motion.h1>
+        {blogContent.title}
+      </motion.h1>
 
-        <motion.p
-            className='text-lg md:text-xl text-gray-300 mb-12 leading-relaxed text-center font-light'
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.4, duration: 0.5 }}
-        >
-          In the ever-evolving landscape of technology, computer science students
-          face an increasingly daunting challenge: landing that coveted internship
-          or dream job. As we step into 2025, the tech industry is undergoing
-          seismic shifts, leaving many aspiring developers feeling lost and
-          overwhelmed. But fear not – there's a way to navigate this treacherous
-          terrain, and I'm here to show you how.
-        </motion.p>
+      <motion.p
+        className='text-lg md:text-xl text-gray-300 mb-12 leading-relaxed text-center font-light'
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.4, duration: 0.5 }}
+      >
+        In the ever-evolving landscape of technology, software engineering
+        students face an increasingly daunting challenge: landing that coveted
+        internship or dream job. As we step into 2025, the tech industry is
+        undergoing seismic shifts, leaving many aspiring developers feeling lost
+        and overwhelmed. But fear not – there's a way to navigate this
+        treacherous terrain, and I'm here to show you how.
+      </motion.p>
 
-        {blogContent.sections.map((section, index) => (
-            <motion.section
-                key={index}
-                className='mb-16'
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.2 * (index + 3), duration: 0.5 }}
-            >
-              <motion.h2 className='text-2xl md:text-3xl font-bold mb-6 text-gray-100 relative overflow-hidden group'>
+      {blogContent.sections.map((section, index) => (
+        <motion.section
+          key={index}
+          className='mb-16'
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 * (index + 3), duration: 0.5 }}
+        >
+          <motion.h2 className='text-2xl md:text-3xl font-bold mb-6 text-gray-100 relative overflow-hidden group'>
             <span className='relative z-10 bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent'>
               {section.title}
             </span>
-                <motion.div
-                    className='absolute bottom-0 left-0 w-full h-0.5 bg-gradient-to-r from-purple-500 to-pink-500'
-                    initial={{ scaleX: 0 }}
-                    whileHover={{ scaleX: 1 }}
-                    transition={{ duration: 0.3 }}
-                />
-              </motion.h2>
-              {section.content.split('\n\n').map((paragraph, pIndex) => (
-                  <motion.p
-                      key={pIndex}
-                      className='text-gray-300 mb-6 leading-relaxed text-lg'
-                      initial={{ opacity: 0, y: 10 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: 0.1 * (pIndex + 1), duration: 0.3 }}
-                  >
-                    {formatTextWithBold(paragraph)}
-                  </motion.p>
-              ))}
-            </motion.section>
-        ))}
-      </motion.article>
+            <motion.div
+              className='absolute bottom-0 left-0 w-full h-0.5 bg-gradient-to-r from-purple-500 to-pink-500'
+              initial={{ scaleX: 0 }}
+              whileHover={{ scaleX: 1 }}
+              transition={{ duration: 0.3 }}
+            />
+          </motion.h2>
+          {section.content.split('\n\n').map((paragraph, pIndex) => (
+            <motion.p
+              key={pIndex}
+              className='text-gray-300 mb-6 leading-relaxed text-lg'
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1 * (pIndex + 1), duration: 0.3 }}
+            >
+              {formatTextWithBold(paragraph)}
+            </motion.p>
+          ))}
+        </motion.section>
+      ))}
+    </motion.article>
   );
 };
 

--- a/components/landingpage/faq.js
+++ b/components/landingpage/faq.js
@@ -5,93 +5,93 @@ const faqData = [
   {
     question: 'How does the waitlist work?',
     answer:
-        "Once you join our waitlist, you'll receive a confirmation email. When we launch the beta version, the first 1,000 waitlist members will receive exclusive access to the platform. We'll notify you via email with instructions to set up your account.",
+      "Once you join our waitlist, you'll receive a confirmation email. When we launch the beta version, the first 1,000 waitlist members will receive exclusive access to the platform. We'll notify you via email with instructions to set up your account.",
   },
   {
     question: 'When will the platform launch?',
     answer:
-        "We're currently in the final stages of development. Beta access will be rolled out in early 2024. Waitlist members will be the first to know and get priority access.",
+      "We're currently in the final stages of development. Beta access will be rolled out in early 2024. Waitlist members will be the first to know and get priority access.",
   },
   {
     question: 'What makes PhazeOne different from other platforms?',
     answer:
-        "We focus on the complete journey, not just job applications. From freshman year guidance to senior year job hunting, we provide personalized roadmaps, insider knowledge, and direct access to opportunities you won't find elsewhere.",
+      "We focus on the complete journey, not just job applications. From freshman year guidance to senior year job hunting, we provide personalized roadmaps, insider knowledge, and direct access to opportunities you won't find elsewhere.",
   },
   {
     question: 'Is it really free?',
     answer:
-        'Yes! Beta users (first 1,000 waitlist members) will receive lifetime access to all premium features completely free. No hidden fees, no credit card required.',
+      'Yes! Beta users (first 1,000 waitlist members) will receive lifetime access to all premium features completely free. No hidden fees, no credit card required.',
   },
   {
     question: 'What kind of support will I receive?',
     answer:
-        "You'll get access to our smart notification system, expert-designed templates, exclusive events, and a supportive community. Beta users also receive priority support from our team.",
+      "You'll get access to our smart notification system, expert-designed templates, exclusive events, and a supportive community. Beta users also receive priority support from our team.",
   },
   {
-    question: "What if I'm not a CS student?",
+    question: "What if I'm not a SWE student?",
     answer:
-        'While our initial focus is on tech careers, our strategies and resources are valuable for any student looking to break into the tech industry, regardless of their major.',
+      'While our initial focus is on tech careers, our strategies and resources are valuable for any student looking to break into the tech industry, regardless of their major.',
   },
   {
     question: 'How will I know when the platform launches?',
     answer:
-        "All waitlist members will receive email updates about our progress and launch timeline. When we're ready to launch, you'll receive detailed instructions on how to access your account.",
+      "All waitlist members will receive email updates about our progress and launch timeline. When we're ready to launch, you'll receive detailed instructions on how to access your account.",
   },
   {
     question: 'Can I share my access with others?',
     answer:
-        'Beta access is individual and tied to your email address. However, we encourage you to tell your friends to join the waitlist to secure their own spot.',
+      'Beta access is individual and tied to your email address. However, we encourage you to tell your friends to join the waitlist to secure their own spot.',
   },
 ];
 
 const FAQ = () => {
   return (
-      <div className='mt-20'>
-        <div className='max-w-6xl mx-auto'>
-          <div className='text-center space-y-3 mb-8'>
-            <h2 className='font-ubuntu text-4xl font-bold'>Have Questions?</h2>
-            <p className='font-ubuntu text-zinc-300'>
-              Find answers to commonly asked questions about PhazeOne
-            </p>
-          </div>
+    <div className='mt-20'>
+      <div className='max-w-6xl mx-auto'>
+        <div className='text-center space-y-3 mb-8'>
+          <h2 className='font-ubuntu text-4xl font-bold'>Have Questions?</h2>
+          <p className='font-ubuntu text-zinc-300'>
+            Find answers to commonly asked questions about PhazeOne
+          </p>
+        </div>
 
-          {/* Grid container for FAQs */}
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6'>
-            {faqData.map((faq, index) => (
-                <div
-                    key={index}
-                    className='bg-[#2A2D3E]/50 backdrop-blur-sm rounded-xl border border-zinc-700/50 hover:border-purple-500/50 transition-all overflow-hidden'
-                >
-                  <button
-                      className='w-full p-4 lg:p-5 text-left flex justify-between items-start gap-4'
-                      onClick={() => {
-                        const el = document.getElementById(`faq-${index}`);
-                        const isExpanded =
-                            el.style.maxHeight !== '0px' && el.style.maxHeight !== '';
-                        el.style.maxHeight = isExpanded
-                            ? '0px'
-                            : `${el.scrollHeight}px`;
-                      }}
-                  >
+        {/* Grid container for FAQs */}
+        <div className='grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6'>
+          {faqData.map((faq, index) => (
+            <div
+              key={index}
+              className='bg-[#2A2D3E]/50 backdrop-blur-sm rounded-xl border border-zinc-700/50 hover:border-purple-500/50 transition-all overflow-hidden'
+            >
+              <button
+                className='w-full p-4 lg:p-5 text-left flex justify-between items-start gap-4'
+                onClick={() => {
+                  const el = document.getElementById(`faq-${index}`);
+                  const isExpanded =
+                    el.style.maxHeight !== '0px' && el.style.maxHeight !== '';
+                  el.style.maxHeight = isExpanded
+                    ? '0px'
+                    : `${el.scrollHeight}px`;
+                }}
+              >
                 <span className='font-ubuntu font-semibold text-base lg:text-lg'>
                   {faq.question}
                 </span>
-                    <ChevronRight className='w-5 h-5 transform transition-transform flex-shrink-0 mt-1' />
-                  </button>
-                  <div
-                      id={`faq-${index}`}
-                      className='max-h-0 overflow-hidden transition-all duration-300 ease-in-out'
-                      style={{ maxHeight: '0px' }}
-                  >
-                    <p className='font-ubuntu px-4 lg:px-5 pb-4 lg:pb-5 text-zinc-300 text-sm lg:text-base'>
-                      {faq.answer}
-                    </p>
-                  </div>
-                </div>
-            ))}
-          </div>
+                <ChevronRight className='w-5 h-5 transform transition-transform flex-shrink-0 mt-1' />
+              </button>
+              <div
+                id={`faq-${index}`}
+                className='max-h-0 overflow-hidden transition-all duration-300 ease-in-out'
+                style={{ maxHeight: '0px' }}
+              >
+                <p className='font-ubuntu px-4 lg:px-5 pb-4 lg:pb-5 text-zinc-300 text-sm lg:text-base'>
+                  {faq.answer}
+                </p>
+              </div>
+            </div>
+          ))}
         </div>
       </div>
+    </div>
   );
 };
 

--- a/components/landingpage/footer.js
+++ b/components/landingpage/footer.js
@@ -5,7 +5,7 @@ import { Twitter, Linkedin, Github, Instagram } from 'lucide-react';
 const footerContent = {
   about: {
     description:
-        'Empowering CS students to land their dream tech roles through personalized guidance and industry insights.',
+      'Empowering SWE students to land their dream tech roles through personalized guidance and industry insights.',
   },
   sections: [
     {
@@ -55,74 +55,74 @@ const footerContent = {
 
 const Footer = () => {
   return (
-      <footer className='mt-16 border-t border-zinc-800'>
-        <div className='mx-auto max-w-7xl px-6 lg:px-8'>
-          <div className='py-8 lg:py-12'>
-            {/* Main Footer Content */}
-            <div className='flex flex-col lg:flex-row lg:justify-between gap-8'>
-              {/* Brand and About Section - Full width on mobile, left side on desktop */}
-              <div className='lg:max-w-sm'>
-                <Link
-                    href='/'
-                    className='font-ubuntu text-2xl font-bold bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent'
-                >
-                  PhazeOne
-                </Link>
-                <p className='font-ubuntu mt-4 text-sm text-zinc-400'>
-                  {footerContent.about.description}
-                </p>
-                {/* Social Links */}
-                <div className='mt-4 flex space-x-4'>
-                  {footerContent.socials.map((social) => {
-                    const Icon = social.icon;
-                    return (
-                        <a
-                            key={social.name}
-                            href={social.href}
-                            className='text-zinc-400 hover:text-white transition-colors'
-                            target='_blank'
-                            rel='noopener noreferrer'
-                        >
-                          <Icon className='h-5 w-5' />
-                        </a>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Navigation Sections - Grid on mobile, flex on desktop */}
-              <div className='grid grid-cols-2 sm:grid-cols-4 gap-8 lg:gap-12'>
-                {footerContent.sections.map((section) => (
-                    <div key={section.title} className='min-w-[140px]'>
-                      <h3 className='font-ubuntu text-sm font-semibold text-white mb-3'>
-                        {section.title}
-                      </h3>
-                      <ul className='space-y-2'>
-                        {section.links.map((link) => (
-                            <li key={link.name}>
-                              <Link
-                                  href={link.href}
-                                  className='font-ubuntu text-sm text-zinc-400 hover:text-white transition-colors'
-                              >
-                                {link.name}
-                              </Link>
-                            </li>
-                        ))}
-                      </ul>
-                    </div>
-                ))}
+    <footer className='mt-16 border-t border-zinc-800'>
+      <div className='mx-auto max-w-7xl px-6 lg:px-8'>
+        <div className='py-8 lg:py-12'>
+          {/* Main Footer Content */}
+          <div className='flex flex-col lg:flex-row lg:justify-between gap-8'>
+            {/* Brand and About Section - Full width on mobile, left side on desktop */}
+            <div className='lg:max-w-sm'>
+              <Link
+                href='/'
+                className='font-ubuntu text-2xl font-bold bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent'
+              >
+                PhazeOne
+              </Link>
+              <p className='font-ubuntu mt-4 text-sm text-zinc-400'>
+                {footerContent.about.description}
+              </p>
+              {/* Social Links */}
+              <div className='mt-4 flex space-x-4'>
+                {footerContent.socials.map((social) => {
+                  const Icon = social.icon;
+                  return (
+                    <a
+                      key={social.name}
+                      href={social.href}
+                      className='text-zinc-400 hover:text-white transition-colors'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                    >
+                      <Icon className='h-5 w-5' />
+                    </a>
+                  );
+                })}
               </div>
             </div>
-          </div>
 
-          {/* Copyright - Smaller padding */}
-          <div className='border-t border-zinc-800 py-6'>
-            <p className='font-ubuntu text-sm text-zinc-400 text-center'>
-              © {new Date().getFullYear()} PhazeOne. All rights reserved.
-            </p>
+            {/* Navigation Sections - Grid on mobile, flex on desktop */}
+            <div className='grid grid-cols-2 sm:grid-cols-4 gap-8 lg:gap-12'>
+              {footerContent.sections.map((section) => (
+                <div key={section.title} className='min-w-[140px]'>
+                  <h3 className='font-ubuntu text-sm font-semibold text-white mb-3'>
+                    {section.title}
+                  </h3>
+                  <ul className='space-y-2'>
+                    {section.links.map((link) => (
+                      <li key={link.name}>
+                        <Link
+                          href={link.href}
+                          className='font-ubuntu text-sm text-zinc-400 hover:text-white transition-colors'
+                        >
+                          {link.name}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
-      </footer>
+
+        {/* Copyright - Smaller padding */}
+        <div className='border-t border-zinc-800 py-6'>
+          <p className='font-ubuntu text-sm text-zinc-400 text-center'>
+            © {new Date().getFullYear()} PhazeOne. All rights reserved.
+          </p>
+        </div>
+      </div>
+    </footer>
   );
 };
 

--- a/components/landingpage/hero.js
+++ b/components/landingpage/hero.js
@@ -5,39 +5,39 @@ import Link from 'next/link';
 
 const Hero = ({ onJoinWaitlist }) => {
   return (
-      <div className='items-center justify-center text-center py-2'>
-        <div className='space-y-6 lg:space-y-8 max-w-3xl mx-auto px-4'>
-          <h1 className='font-ubuntu text-5xl lg:text-6xl font-bold leading-tight'>
-            Kickstart
-            <span className='font-ubuntu bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent block pb-2'>
+    <div className='items-center justify-center text-center py-2'>
+      <div className='space-y-6 lg:space-y-8 max-w-3xl mx-auto px-4'>
+        <h1 className='font-ubuntu text-5xl lg:text-6xl font-bold leading-tight'>
+          Kickstart
+          <span className='font-ubuntu bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent block pb-2'>
             Your Tech Journey
           </span>
-          </h1>
+        </h1>
 
-          <p className='font-ubuntu text-zinc-400 text-lg lg:text-xl leading-relaxed'>
-            Democratizing access to the best curated resources for CS students.
-            From hackathons to internships, we provide the perfect starting point
-            for your tech journey.
-          </p>
+        <p className='font-ubuntu text-zinc-400 text-lg lg:text-xl leading-relaxed'>
+          Democratizing access to the best curated resources for Software
+          Engineering students. From hackathons to internships, we provide the
+          perfect starting point for your tech journey.
+        </p>
 
-          <div className='flex flex-col lg:flex-row items-center justify-center space-y-2 lg:space-y-0 lg:space-x-2'>
-            <button
-                onClick={onJoinWaitlist}
-                className='font-ubuntu group px-8 py-4 rounded-lg font-medium bg-gradient-to-r from-purple-500 to-pink-500 hover:shadow-lg hover:shadow-purple-500/20 hover:scale-105 transition-all duration-300 flex items-center text-sm'
-            >
-              Join Waitlist
-              <ChevronRight className='ml-1 w-6 h-6 group-hover:translate-x-1 transition-transform' />
-            </button>
-            <Link
-                href='/blog'
-                className='font-ubuntu group px-8 py-4 rounded-lg font-medium bg-zinc-900 border border-zinc-700/50 hover:border-purple-500/50 hover:shadow-lg hover:shadow-purple-500/20 hover:scale-105 transition-all duration-300 flex items-center text-zinc-400 hover:text-white text-sm'
-            >
-              Learn More
-              <ChevronRight className='ml-1 w-6 h-6 group-hover:translate-x-1 transition-transform' />
-            </Link>
-          </div>
+        <div className='flex flex-col lg:flex-row items-center justify-center space-y-2 lg:space-y-0 lg:space-x-2'>
+          <button
+            onClick={onJoinWaitlist}
+            className='font-ubuntu group px-8 py-4 rounded-lg font-medium bg-gradient-to-r from-purple-500 to-pink-500 hover:shadow-lg hover:shadow-purple-500/20 hover:scale-105 transition-all duration-300 flex items-center text-sm'
+          >
+            Join Waitlist
+            <ChevronRight className='ml-1 w-6 h-6 group-hover:translate-x-1 transition-transform' />
+          </button>
+          <Link
+            href='/blog'
+            className='font-ubuntu group px-8 py-4 rounded-lg font-medium bg-zinc-900 border border-zinc-700/50 hover:border-purple-500/50 hover:shadow-lg hover:shadow-purple-500/20 hover:scale-105 transition-all duration-300 flex items-center text-zinc-400 hover:text-white text-sm'
+          >
+            Learn More
+            <ChevronRight className='ml-1 w-6 h-6 group-hover:translate-x-1 transition-transform' />
+          </Link>
         </div>
       </div>
+    </div>
   );
 };
 

--- a/middleware.js
+++ b/middleware.js
@@ -5,6 +5,25 @@ import { updateSession } from './lib/supabase/middleware';
 const PROTECTED_ROUTES = ['/login', '/dashboard'];
 
 export async function middleware(request) {
+  const { pathname } = request.nextUrl;
+
+  // Check if the current path is a protected route
+  const isProtectedRoute = PROTECTED_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`)
+  );
+
+  // Always allow access in development environment
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
+  // If it's a protected route and we're in production, redirect to home
+  if (isProtectedRoute && !isDevelopment) {
+    // Redirect to your home
+    const url = request.nextUrl.clone();
+    url.pathname = '/';
+    return NextResponse.redirect(url);
+  }
+
+  // If not redirecting, update the session as before
   return await updateSession(request);
 }
 

--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,8 @@
+import { NextResponse } from 'next/server';
 import { updateSession } from './lib/supabase/middleware';
+
+// Routes to protect
+const PROTECTED_ROUTES = ['/login', '/dashboard'];
 
 export async function middleware(request) {
   return await updateSession(request);


### PR DESCRIPTION
This PR does the following changes: 
- Does a rebrand on texts contents from CS students to SWE students
- Updates the re-route page that gets displayed whenever a user tries to access an inaccessible route to the `/` home page
- Adds some logic in `middleware.ts` file to hide the `/login` and `/dashboard` routes in prod but still makes them accessible locally